### PR TITLE
Fix: responsive bug

### DIFF
--- a/bin/assets/styles/style.css
+++ b/bin/assets/styles/style.css
@@ -80,9 +80,8 @@ tr, td {
 }
 
 .controls {
-    position: absolute;
+    position: fixed;
     bottom: 0;
-    left: 0;
     right: 0;
     padding: 0 1.5em 1em 0.5em;
     pointer-events: none;


### PR DESCRIPTION
Les butons controls se trouvaient en plein milieu de la page, notamment sur la version mobile,
Avant:
![image](https://user-images.githubusercontent.com/60854021/107770829-36cf0600-6d3a-11eb-8dfc-bae3e3d1b391.png)
Après:
![image](https://user-images.githubusercontent.com/60854021/107770900-40586e00-6d3a-11eb-8988-c9e34c1b24d0.png)
(C'est normal pour la coloration syntaxique, elle ne sera pas affecté sur la PR)